### PR TITLE
Fix for replica flag not working

### DIFF
--- a/lib/puppet/parser/functions/ucp_join_flags.rb
+++ b/lib/puppet/parser/functions/ucp_join_flags.rb
@@ -14,7 +14,11 @@ module Puppet::Parser::Functions
     unless opts['usage']
       flags << '--disable-usage'
     end
-
+    
+    if opts['replica'] == true
+      flags << '--replica'	    
+    end  	    
+    
     if opts['version'] && opts['version'].to_s != 'undef'
       flags << "--image-version '#{opts['version']}'"
     end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -209,7 +209,7 @@ class docker_ucp(
         extra_parameters   => any2array($extra_parameters),
       })
       exec { 'Join Docker Universal Control Plane':
-        command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock -e 'UCP_ADMIN_USER=${username}' -e 'UCP_ADMIN_PASSWORD=${password}' --name ucp docker/ucp join --replica ${join_flags}",
+        command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock -e 'UCP_ADMIN_USER=${username}' -e 'UCP_ADMIN_PASSWORD=${password}' --name ucp docker/ucp join ${join_flags}",
         unless  => "docker inspect ${::hostname}/ucp-proxy",
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -201,6 +201,7 @@ class docker_ucp(
         version            => $version,
         fingerprint        => $fingerprint,
         ucp_url            => $ucp_url,
+        replica            => $replica,
         dns_servers        => any2array($dns_servers),
         dns_options        => any2array($dns_options),
         dns_search_domains => any2array($dns_search_domains),
@@ -208,7 +209,7 @@ class docker_ucp(
         extra_parameters   => any2array($extra_parameters),
       })
       exec { 'Join Docker Universal Control Plane':
-        command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock -e 'UCP_ADMIN_USER=${username}' -e 'UCP_ADMIN_PASSWORD=${password}' --name ucp docker/ucp join ${join_flags}",
+        command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock -e 'UCP_ADMIN_USER=${username}' -e 'UCP_ADMIN_PASSWORD=${password}' --name ucp docker/ucp join --replica ${join_flags}",
         unless  => "docker inspect ${::hostname}/ucp-proxy",
       }
     }


### PR DESCRIPTION
This pull requests fix the replica flag not working even when set to true.

Before adding the code in the PR Puppet would output the following 

```
'docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e 'UCP_ADMIN_USER=admin' -e 'UCP_ADMIN_PASSWORD=orca' --name ucp docker/ucp join --host-address '172.17.10.102' --image-version '1.1.0' --fingerprint 'D5:34:8A:EC:7E:0C:35:33:68:3B:BC:35:B0:36:AB:22:C8:D6:C2:8B' --url 'https://172.17.10.101' --san '10.0.2.15' '
```

After the PR code is added 

```
'docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -e 'UCP_ADMIN_USER=admin' -e 'UCP_ADMIN_PASSWORD=orca' --name ucp docker/ucp join --replica --host-address '172.17.10.102' --replica --image-version '1.1.0' --fingerprint 'AC:DE:9F:85:C2:59:0E:1D:6F:C3:1B:B3:50:85:85:58:F3:1E:27:EF' --url 'https://172.17.10.101' --san '10.0.2.15' '
```

Allowing you to create full controller replicas, not just nodes 
