### PR TITLE
Resubmission for PR #4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -211,7 +211,7 @@ Style/SpaceInsideParens:
 Style/LeadingCommentSpace:
   Enabled: false
 
-Style/SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/SpaceAfterColon:
@@ -220,7 +220,7 @@ Style/SpaceAfterColon:
 Style/SpaceAfterComma:
   Enabled: false
 
-Style/SpaceAfterControlKeyword:
+Style/SpaceAroundKeyword:
   Enabled: false
 
 Style/SpaceAfterMethodName:
@@ -321,9 +321,6 @@ Style/TrailingWhitespace:
   Enabled: false
 
 Style/StringLiterals:
-  Enabled: false
-
-Style/TrailingComma:
   Enabled: false
 
 Style/GlobalVars:
@@ -464,7 +461,7 @@ Metrics/ParameterLists:
 Lint/RequireParentheses:
   Enabled: false
 
-Lint/SpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 
 Style/ModuleFunction:
@@ -478,3 +475,13 @@ Style/IfWithSemicolon:
 
 Style/Encoding:
   Enabled: false
+
+Style/TrailingCommaInLiteral:
+  Enabled: false
+
+Style/MultilineMethodCallIndentation:
+  Enabled: false  
+
+Lint/Void:
+  Enabled: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ script: bundle exec rake test
 matrix:
   fast_finish: true
   include:
+  - rvm: 2.2.5
+    env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.6
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes"
   - rvm: 2.1.5
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.5
-    env: PUPPET_GEM_VERSION="~> 3.0"
-  - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rake'
+  gem 'rake', ' 10.4.2'
   gem 'puppet', ENV['PUPPET_GEM_VERSION'] || '~> 4.3.0'
   gem 'rspec', '< 3.2.0'
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'puppetlabs_spec_helper'
   gem 'metadata-json-lint'
   gem 'rspec-puppet-facts'
-  gem 'rubocop', '0.33.0'
+  gem 'rubocop', '0.40.0'
   gem 'simplecov'
   gem 'simplecov-console'
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ later than 0.8.0.
 
 ### Joining a Node to UCP
 
+# Version =< 1
 You can use the same class on another node to join it to an existing
 UCP.
 
@@ -103,6 +104,19 @@ class { 'docker_ucp':
   version                   => '0.8.0',
   usage                     => false,
   tracking                  => false,
+}
+```
+# Version 2 and above
+In UCP version 2 Docker has changed the underlying cluster scheduler from Swarm legacy to Swarm mode, because of that change the join flags have also changed.
+To join to a v2 manager (formally a controller in v1) please use the following:
+
+```puppet
+class { 'docker_ucp':
+  version => '2.1.0',
+  token => 'Your join token here',
+  listen_address => '192.168.1.2',
+  advertise_address => '192.168.1.2',
+  ucp_manager => '192.168.1.1',
 }
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ exclude_paths = [
 
 # Coverage from puppetlabs-spec-helper requires rcov which
 # doesn't work in anything since 1.8.7
-Rake::Task[:coverage].clear
+#Rake::Task[:coverage].clear
 
 Rake::Task[:lint].clear
 

--- a/lib/puppet/parser/functions/ucp_install_flags.rb
+++ b/lib/puppet/parser/functions/ucp_install_flags.rb
@@ -2,6 +2,14 @@ module Puppet::Parser::Functions
   newfunction(:ucp_install_flags, :type => :rvalue) do |args|
     opts = args[0] || {}
     flags = []
+    
+    if opts['admin_username'].to_s != 'undef'
+      flags << "--admin-username '#{opts['admin_username']}'"
+    end      
+    
+    if opts['admin_password'].to_s != 'undef'
+      flags << "--admin-password '#{opts['admin_password']}'"
+    end      
 
     if opts['host_address'] && opts['host_address'].to_s != 'undef'
       flags << "--host-address '#{opts['host_address']}'"

--- a/spec/acceptance/docker_ucp_spec.rb
+++ b/spec/acceptance/docker_ucp_spec.rb
@@ -8,7 +8,7 @@ UCP_PORTS = [
   12380,
   12381,
   12382,
-]
+].freeze
 
 UCP_CONTROLLER_CONTAINERS = [
   'controller',
@@ -19,7 +19,7 @@ UCP_CONTROLLER_CONTAINERS = [
   'swarm-manager',
   'proxy',
   'kv',
-]
+].freeze
 
 describe 'docker_ucp' do
   context 'installation' do

--- a/spec/classes/docker_ucp_spec.rb
+++ b/spec/classes/docker_ucp_spec.rb
@@ -223,20 +223,21 @@ describe 'docker_ucp' do
           end
         end
 
-        context 'joining UCP' do
-          context 'with the minimum properties' do
+        context 'joining UCP v1' do
+          context 'with the minimum properties v1' do
             let(:fingerprint) { '12345' }
             let(:ucp_url) { 'https://ucp' }
-            let(:params) do
+	    let(:params) do
               {
-                'fingerprint' => fingerprint,
+		'version' => '1.0',
+		'fingerprint' => fingerprint,
                 'ucp_url' => ucp_url,
               }
             end
-            it do
-              should contain_class('Docker_ucp').with_controller(false)
-              should contain_exec('Join Docker Universal Control Plane')
-                .with_logoutput(true)
+	    it do
+	      should contain_class('Docker_ucp').with_controller(false)
+              should contain_exec('Join Docker Universal Control Plane v1')
+		.with_logoutput(true)
                 .with_tries(3)
                 .with_try_sleep(5)
                 .with_command(/join/)
@@ -247,9 +248,44 @@ describe 'docker_ucp' do
                 .with_command(/\-\-disable\-usage/)
               should_not contain_exec('Install Docker Universal Control Plane')
                 .with_command(/\-\-disable\-tracking/)
-            end
-          end
-          context 'without passing a fingerprint' do
+               end 
+              end
+	    end
+	    
+	   context 'joining UCP v2' do
+	     context 'with the minimum properties v2' do
+               let(:token) { 'abc' }
+               let(:listen_address) { '192.168.1.1' }
+               let(:advertise_address) { '192.168.1.1' }
+               let(:ucp_manager) { '192.168.1.100' }
+               let(:params) do  
+	         {
+		   'version' => '2',
+		   'token' => token,
+		   'listen_address' => listen_address,
+		   'advertise_address' => advertise_address,
+		   'ucp_manager' => ucp_manager,
+	         }
+	       it do
+		 should contain_class('Docker_ucp')
+		 should contain_exec('Join Docker Universal Control Plane v2')
+	           .with_logoutput(true)
+		   .with_tries(3)
+		   .with_try_sleep(5)
+		   .with_command(/join/)
+		   .with_command(/\-\-token '#{token}'/)
+		   .with_command(/\-\-listen_addr '#{listen_address}'/)
+		   .with_command(/\-\-advertise_addr '#{advertise_address}'/)
+		   .with_unless('docker inspect foo/ucp-proxy')
+		 should_not contain_exec('Install Docker Universal Control Plane')
+		   .with_command(/\-\-disable\-usage/)
+		 should_not contain_exec('Install Docker Universal Control Plane')
+		 should_not contain_exec('Join Docker Universal Control Plane v1')
+               end
+             end
+           
+	  
+	  context 'without passing a fingerprint' do
             let(:params) do
               {
                 'ucp_url' => 'https://ucp',
@@ -257,19 +293,21 @@ describe 'docker_ucp' do
             end
             it do
               expect { # rubocop:disable Style/BlockDelimiters
-                should contain_exec('Join Docker Universal Control Plane')
-              }.to raise_error(Puppet::Error, /When joining UCP you must provide a fingerprint/)
+                should contain_exec('Join Docker Universal Control Plane v1')
+	      }.to raise_error(Puppet::Error, /When joining UCP you must provide a fingerprint/)
             end
-          end
-          context 'without passing a UCP URL' do
-            let(:params) do
+         end
+         context 'without passing a UCP URL' do
+           let(:params) do
               {
                 'fingerprint' => '12345',
+		'version'     => '1',
               }
             end
             it do
               expect { # rubocop:disable Style/BlockDelimiters
-                should contain_exec('Join Docker Universal Control Plane')
+                should contain_exec('Join Docker Universal Control Plane v1')
+		should_not contain_exec('Join Docker Universal Control Plane v2')
               }.to raise_error(Puppet::Error, /When joining UCP you must provide a URL/)
             end
           end
@@ -332,10 +370,11 @@ describe 'docker_ucp' do
               expect { # rubocop:disable Style/BlockDelimiters
                 should contain_exec('Uninstall Docker Universal Control Plane')
               }.to raise_error(Puppet::Error, /When passing ensure => absent you must also provide the UCP id/)
+              end
             end
           end
         end
       end
     end
   end
-end
+end  

--- a/spec/support/system_running_ucp.rb
+++ b/spec/support/system_running_ucp.rb
@@ -8,7 +8,7 @@ UCP_IMAGES = [
   'auth-store',
   'swarm',
   'dsinfo',
-]
+].freeze
 
 
 shared_examples 'a system running UCP' do


### PR DESCRIPTION
This PR fixes the issue that the root user name and password was not being set properly. It was always being set as admin ```orca``` In UCP 2.0 there is a specification for the password to be 8 characters long. If you apply ```orca``` as the password UCP with respond with a hash password it has created. This breaks the functionality of being able to build UCP clusters at scale with this module. You are also unable to use UCP v2 and above with the module. That has now been fixed with a new join command passed in ```version => 2``` is passed. As Docker still supports all versions of UCP the join command for version 1 and below was left untouched