### PR TITLE
fix for metadata.json removing pe

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -33,10 +33,6 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">= 3.7.0 < 2016.1.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.8.0 < 5.0.0"
     }


### PR DESCRIPTION
This is a fix for the tests not running. The PE requirement in the metadata.json file is no longer required